### PR TITLE
Taylor more level stuff

### DIFF
--- a/PenguinsCanFly/Assets/Scenes/MasterScene.unity
+++ b/PenguinsCanFly/Assets/Scenes/MasterScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.43020576, g: 0.56304204, b: 0.71133375, a: 1}
+  m_IndirectSpecularColor: {r: 0.43062702, g: 0.56337565, b: 0.7113785, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1872,6 +1872,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   penguinXROTransform: {fileID: 2078797934}
   obstacleTypes:
+  - {fileID: 2733523344670738679, guid: 1bcbe3603509c486bbe075a8a9e68ebf, type: 3}
   - {fileID: 2733523344670738679, guid: 1bcbe3603509c486bbe075a8a9e68ebf, type: 3}
   - {fileID: 5296170243713047716, guid: 0627e719efc3c48549c06799a8cae4da, type: 3}
 --- !u!4 &437040826

--- a/PenguinsCanFly/Assets/Scripts/Checkpoint.cs
+++ b/PenguinsCanFly/Assets/Scripts/Checkpoint.cs
@@ -16,11 +16,11 @@ public class Checkpoint : MonoBehaviour
 
     private void Update()
     {
+        // Destroy checkpoint when the user is past it
         float gliderPositionZ = GameController.Instance.gliderInfo.penguinXROTransform.position.z;
         float selfPositionZ = transform.position.z;
         if (selfPositionZ - gliderPositionZ < -20f)
         {
-            // Destroy checkpoint when the user is past it
             Destroy(gameObject);
         }
     }

--- a/PenguinsCanFly/Assets/Scripts/Checkpoint.cs
+++ b/PenguinsCanFly/Assets/Scripts/Checkpoint.cs
@@ -8,6 +8,8 @@ public class Checkpoint : MonoBehaviour
     private const string HangGliderTag = "HangGlider";
     private float pitchToAdd = -20f;  // Negative to pitch up, positive to pitch down
 
+    public const float CheckpointHeightIncrease = 2f;
+
     // Start is called before the first frame update
     void Start()
     {
@@ -35,11 +37,13 @@ public class Checkpoint : MonoBehaviour
 
     IEnumerator IncreaseHeight()
     {
-        for (int i = 0; i < 100; i++)
+        float iterations = 200;  // iterations * WaitForSeconds = length of time to apply height increase over
+        float heightIncreasePerIteration = CheckpointHeightIncrease / iterations;
+        for (int i = 0; i < iterations; i++)
         {
-            GameController.Instance.gliderInfo.penguinXRORigidbody.AddForce(Vector3.up * 20);
+            GameController.Instance.gliderInfo.penguinXROTransform.position += Vector3.up * heightIncreasePerIteration;
             GameController.Instance.gliderInfo.extraPitchDegree += pitchToAdd;
-            yield return null;
+            yield return new WaitForSeconds(0.01f);
         }
     }
 }

--- a/PenguinsCanFly/Assets/Scripts/Checkpoint.cs
+++ b/PenguinsCanFly/Assets/Scripts/Checkpoint.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -11,21 +12,24 @@ public class Checkpoint : MonoBehaviour
     void Start()
     {
     }
-    
-    
+
+
+    private void Update()
+    {
+        float gliderPositionZ = GameController.Instance.gliderInfo.penguinXROTransform.position.z;
+        float selfPositionZ = transform.position.z;
+        if (selfPositionZ - gliderPositionZ < -20f)
+        {
+            // Destroy checkpoint when the user is past it
+            Destroy(gameObject);
+        }
+    }
+
     private void OnTriggerEnter(Collider other)
     {
         if (other.gameObject.CompareTag(HangGliderTag))
         {
             StartCoroutine(IncreaseHeight());
-        }
-    }
-    
-    private void OnTriggerExit(Collider other)
-    {
-        if (other.gameObject.CompareTag(HangGliderTag))
-        {
-            Destroy(gameObject);
         }
     }
 

--- a/PenguinsCanFly/Assets/Scripts/Checkpoint.cs
+++ b/PenguinsCanFly/Assets/Scripts/Checkpoint.cs
@@ -20,6 +20,14 @@ public class Checkpoint : MonoBehaviour
             StartCoroutine(IncreaseHeight());
         }
     }
+    
+    private void OnTriggerExit(Collider other)
+    {
+        if (other.gameObject.CompareTag(HangGliderTag))
+        {
+            Destroy(gameObject);
+        }
+    }
 
     IEnumerator IncreaseHeight()
     {

--- a/PenguinsCanFly/Assets/Scripts/DeviceManager.cs
+++ b/PenguinsCanFly/Assets/Scripts/DeviceManager.cs
@@ -63,4 +63,10 @@ public class DeviceManager : MonoBehaviour
             leftHandDevice = inputDevices[0];
         }
     }
+
+    public void SendCollisionHaptics()
+    {
+        leftHandDevice.SendHapticImpulse(0, 1, 0.5f);
+        rightHandDevice.SendHapticImpulse(0, 1, 0.5f);
+    }
 }

--- a/PenguinsCanFly/Assets/Scripts/LevelManager.cs
+++ b/PenguinsCanFly/Assets/Scripts/LevelManager.cs
@@ -90,14 +90,12 @@ public class LevelManager : MonoBehaviour
 
         // Generate cosmetic obstacles
         int numCosmeticLower = Math.Max(2, (int) penguinXROTransform.position.y / 50);
-        Debug.Log("lower: " + numCosmeticLower);
         for (int i = 0; i < numCosmeticLower; i++)
         {
             SpawnRandomObstacle(startOfInterval, GetPositionForCosmeticObstacleLower);
         }
         
         int numCosmeticHigher = Math.Max(2, (int)(MaxObstacleHeight - penguinXROTransform.position.y) / 50);
-        Debug.Log("higher: " + numCosmeticHigher);
         for (int i = 0; i < numCosmeticHigher; i++)
         {
             SpawnRandomObstacle(startOfInterval, GetPositionForCosmeticObstacleHigher);

--- a/PenguinsCanFly/Assets/Scripts/LevelManager.cs
+++ b/PenguinsCanFly/Assets/Scripts/LevelManager.cs
@@ -24,6 +24,9 @@ public class LevelManager : MonoBehaviour
 
     public GameObject[] obstacleTypes;
 
+    // TODO: remove, this is for debugging purposes
+    public static int NumObstaclesActiveInGame = 0;
+        
     // Start is called before the first frame update
     void Start()
     {
@@ -62,7 +65,8 @@ public class LevelManager : MonoBehaviour
             GenerateObstacles(_totalDistance + GenerateDistance);
             _numObstacleIntervalsGenerated++;
         }
-
+        
+        Debug.Log("SAVE:numObstaclesActive:" + NumObstaclesActiveInGame);
     }
 
     private float GetCheckpointInterval()
@@ -89,17 +93,17 @@ public class LevelManager : MonoBehaviour
         }
 
         // Generate cosmetic obstacles
-        int numCosmeticLower = Math.Max(2, (int) penguinXROTransform.position.y / 50);
-        for (int i = 0; i < numCosmeticLower; i++)
-        {
-            SpawnRandomObstacle(startOfInterval, GetPositionForCosmeticObstacleLower);
-        }
-        
-        int numCosmeticHigher = Math.Max(2, (int)(MaxObstacleHeight - penguinXROTransform.position.y) / 50);
-        for (int i = 0; i < numCosmeticHigher; i++)
-        {
-            SpawnRandomObstacle(startOfInterval, GetPositionForCosmeticObstacleHigher);
-        }
+        // int numCosmeticLower = Math.Max(2, (int) penguinXROTransform.position.y / 100);
+        // for (int i = 0; i < numCosmeticLower; i++)
+        // {
+        //     SpawnRandomObstacle(startOfInterval, GetPositionForCosmeticObstacleLower);
+        // }
+        //
+        // int numCosmeticHigher = Math.Max(2, (int)(MaxObstacleHeight - penguinXROTransform.position.y) / 100);
+        // for (int i = 0; i < numCosmeticHigher; i++)
+        // {
+        //     SpawnRandomObstacle(startOfInterval, GetPositionForCosmeticObstacleHigher);
+        // }
     }
 
     private void SpawnRandomObstacle(float startOfInterval, Func<Obstacle, float, Vector3> getPositionForObstacle)
@@ -130,6 +134,7 @@ public class LevelManager : MonoBehaviour
         {
             // Spawn the obstacle here
             Instantiate(obstacle, position, obstacleScript.GetSpawnRotation());
+            NumObstaclesActiveInGame++;
         }
     }
 
@@ -148,7 +153,7 @@ public class LevelManager : MonoBehaviour
     {
         // TODO: maybe this x range is too wide
         float x = Random.Range(-200, 200);
-        float y = Random.Range(0, obstacleScript.GetSpawnOffsetLowerBound() + penguinXROTransform.position.y);
+        float y = Random.Range(10, obstacleScript.GetSpawnOffsetLowerBound() + penguinXROTransform.position.y);
         float z = startOfInterval + Random.Range(0, ObstacleInterval);
         return new Vector3(x, y, z);
     }

--- a/PenguinsCanFly/Assets/Scripts/LevelManager.cs
+++ b/PenguinsCanFly/Assets/Scripts/LevelManager.cs
@@ -61,7 +61,7 @@ public class LevelManager : MonoBehaviour
             StartCoroutine(IncreaseSpeed(GetSpeedIncrease()));
             
             _locationOfLastCheckpoint = Single.MaxValue;
-            GenerateCheckpoint(0);
+            GenerateCheckpoint();
             _numCheckpointsInstantiated++;
         }
 
@@ -79,9 +79,8 @@ public class LevelManager : MonoBehaviour
         // TODO: change this to depend on speed
         return 500f;
     }
-
-    // TODO: clean up parameter
-    public void GenerateCheckpoint(float location)
+    
+    public void GenerateCheckpoint()
     {
         GliderInfo gliderInfo = GameController.Instance.gliderInfo;
 

--- a/PenguinsCanFly/Assets/Scripts/LevelManager.cs
+++ b/PenguinsCanFly/Assets/Scripts/LevelManager.cs
@@ -27,28 +27,7 @@ public class LevelManager : MonoBehaviour
 
     // TODO: remove, this is for debugging purposes
     public static int NumObstaclesActiveInGame = 0;
-    
-    private static LevelManager _instance;
 
-    public static LevelManager Instance
-    {
-        get
-        {
-            return _instance;
-        }
-    }
-    
-    private void Awake()
-    {
-        if (_instance != null && _instance != this)
-        {
-            Destroy(gameObject);
-            return;
-        }
-        _instance = this;
-    }
-
-    
     // Start is called before the first frame update
     void Start()
     {

--- a/PenguinsCanFly/Assets/Scripts/Obstacles/BalloonObstacle.cs
+++ b/PenguinsCanFly/Assets/Scripts/Obstacles/BalloonObstacle.cs
@@ -15,11 +15,13 @@ public class BalloonObstacle : Obstacle
     }
 
     // Update is called once per frame
-    void Update() {
+    new void Update()
+    {
+        base.Update();
         float y = Mathf.Sin(Time.time * _speed) * _height;
         transform.position += Vector3.up * y;
     }
-    
+
     public override float GetSpawnOffsetLowerBound()
     {
         return -20f;

--- a/PenguinsCanFly/Assets/Scripts/Obstacles/Obstacle.cs
+++ b/PenguinsCanFly/Assets/Scripts/Obstacles/Obstacle.cs
@@ -6,6 +6,8 @@ public abstract class Obstacle : MonoBehaviour
 {
     private const string HangGliderTag = "HangGlider";
     private float pitchToAdd = 3f;  // Negative to pitch up, positive to pitch down
+
+    private const float DestroyDistance = 1000f;
     
     public abstract float GetSpawnOffsetLowerBound();
     public abstract float GetSpawnOffsetUpperBound();
@@ -13,7 +15,16 @@ public abstract class Obstacle : MonoBehaviour
 
     public void Update()
     {
+        // Destroy obstacle if it falls below the ground
         if (transform.position.y < -20)
+        {
+            Destroy(gameObject);
+        }
+        
+        // Destroy obstacle when the user is too far past it
+        float gliderPositionZ = GameController.Instance.gliderInfo.penguinXROTransform.position.z;
+        float selfPositionZ = transform.position.z;
+        if (selfPositionZ - gliderPositionZ < -DestroyDistance)
         {
             Destroy(gameObject);
         }

--- a/PenguinsCanFly/Assets/Scripts/Obstacles/Obstacle.cs
+++ b/PenguinsCanFly/Assets/Scripts/Obstacles/Obstacle.cs
@@ -8,6 +8,8 @@ public abstract class Obstacle : MonoBehaviour
     private float pitchToAdd = 3f;  // Negative to pitch up, positive to pitch down
 
     private const float DestroyDistance = 1000f;
+
+    public const float ObstacleHeightDecrease = 3f;
     
     public abstract float GetSpawnOffsetLowerBound();
     public abstract float GetSpawnOffsetUpperBound();
@@ -53,11 +55,13 @@ public abstract class Obstacle : MonoBehaviour
 
     IEnumerator DecreaseHeight()
     {
-        for (int i = 0; i < 100; i++)
+        float iterations = 200;  // iterations * WaitForSeconds = length of time to apply height increase over
+        float heightIncDecreasePerIteration = ObstacleHeightDecrease / iterations;
+        for (int i = 0; i < iterations; i++)
         {
-            GameController.Instance.gliderInfo.penguinXRORigidbody.AddForce(Vector3.down * 5);
+            GameController.Instance.gliderInfo.penguinXROTransform.position += Vector3.down * heightIncDecreasePerIteration;
             GameController.Instance.gliderInfo.extraPitchDegree += pitchToAdd;
-            yield return null;
+            yield return new WaitForSeconds(0.01f);
         }
     }
 }

--- a/PenguinsCanFly/Assets/Scripts/Obstacles/Obstacle.cs
+++ b/PenguinsCanFly/Assets/Scripts/Obstacles/Obstacle.cs
@@ -36,6 +36,7 @@ public abstract class Obstacle : MonoBehaviour
     {
         if (other.gameObject.CompareTag(HangGliderTag))
         {
+            DeviceManager.Instance.SendCollisionHaptics();
             StartCoroutine(DecreaseHeight());
         }
     }

--- a/PenguinsCanFly/Assets/Scripts/Obstacles/Obstacle.cs
+++ b/PenguinsCanFly/Assets/Scripts/Obstacles/Obstacle.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using System.Collections;
 
@@ -9,13 +10,34 @@ public abstract class Obstacle : MonoBehaviour
     public abstract float GetSpawnOffsetLowerBound();
     public abstract float GetSpawnOffsetUpperBound();
     public abstract Quaternion GetSpawnRotation();
-    
-    private void OnTriggerEnter(Collider other)
+
+    public void Update()
+    {
+        if (transform.position.y < -20)
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    public void OnTriggerEnter(Collider other)
     {
         if (other.gameObject.CompareTag(HangGliderTag))
         {
             StartCoroutine(DecreaseHeight());
         }
+    }
+
+    public void OnTriggerExit(Collider other)
+    {
+        if (other.gameObject.CompareTag(HangGliderTag))
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    void OnDestroy()
+    {
+        LevelManager.NumObstaclesActiveInGame--;
     }
 
     IEnumerator DecreaseHeight()

--- a/PenguinsCanFly/Assets/Scripts/Obstacles/SnowflakeObstacle.cs
+++ b/PenguinsCanFly/Assets/Scripts/Obstacles/SnowflakeObstacle.cs
@@ -14,8 +14,9 @@ public class SnowflakeObstacle : Obstacle
     }
 
     // Update is called once per frame
-    void Update()
+    new void Update()
     {
+        base.Update();
         transform.Rotate((20f+_rotateOffset) * Vector3.forward * Time.deltaTime);
     }
 
@@ -36,4 +37,5 @@ public class SnowflakeObstacle : Obstacle
         rotation.eulerAngles = new Vector3(0, 0,Random.Range(0, 360));
         return rotation;
     }
+    
 }

--- a/PenguinsCanFly/ProjectSettings/EditorBuildSettings.asset
+++ b/PenguinsCanFly/ProjectSettings/EditorBuildSettings.asset
@@ -6,9 +6,6 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 0
-    path: Assets/Scenes/MananScene.unity
-    guid: 08a04579e113e46bca4126b2cde8c2ea
-  - enabled: 1
     path: Assets/Scenes/MasterScene.unity
     guid: 75903851234dc4227afc159cdaf31dc9
   m_configObjects:

--- a/PenguinsCanFly/ProjectSettings/ProjectSettings.asset
+++ b/PenguinsCanFly/ProjectSettings/ProjectSettings.asset
@@ -741,6 +741,44 @@ PlayerSettings:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
   - {fileID: 11400000, guid: 8383bc818588f794f82d39eafdf30719, type: 2}
   - {fileID: 0}
   - {fileID: -8158722226129811354, guid: 76fd00d40ec5aca4781936bf3d94abd7, type: 2}

--- a/PenguinsCanFly/ProjectSettings/ProjectSettings.asset
+++ b/PenguinsCanFly/ProjectSettings/ProjectSettings.asset
@@ -730,6 +730,8 @@ PlayerSettings:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
   - {fileID: 11400000, guid: 8383bc818588f794f82d39eafdf30719, type: 2}
   - {fileID: 0}
   - {fileID: -8158722226129811354, guid: 76fd00d40ec5aca4781936bf3d94abd7, type: 2}

--- a/PenguinsCanFly/ProjectSettings/ProjectSettings.asset
+++ b/PenguinsCanFly/ProjectSettings/ProjectSettings.asset
@@ -733,6 +733,10 @@ PlayerSettings:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
   - {fileID: 11400000, guid: 8383bc818588f794f82d39eafdf30719, type: 2}
   - {fileID: 0}
   - {fileID: -8158722226129811354, guid: 76fd00d40ec5aca4781936bf3d94abd7, type: 2}

--- a/PenguinsCanFly/ProjectSettings/ProjectSettings.asset
+++ b/PenguinsCanFly/ProjectSettings/ProjectSettings.asset
@@ -732,6 +732,7 @@ PlayerSettings:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
+  - {fileID: 0}
   - {fileID: 11400000, guid: 8383bc818588f794f82d39eafdf30719, type: 2}
   - {fileID: 0}
   - {fileID: -8158722226129811354, guid: 76fd00d40ec5aca4781936bf3d94abd7, type: 2}

--- a/PenguinsCanFly/ProjectSettings/ProjectSettings.asset
+++ b/PenguinsCanFly/ProjectSettings/ProjectSettings.asset
@@ -738,6 +738,12 @@ PlayerSettings:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 11400000, guid: 8383bc818588f794f82d39eafdf30719, type: 2}
+  - {fileID: 0}
+  - {fileID: -8158722226129811354, guid: 76fd00d40ec5aca4781936bf3d94abd7, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1

--- a/PenguinsCanFly/ProjectSettings/ProjectSettings.asset
+++ b/PenguinsCanFly/ProjectSettings/ProjectSettings.asset
@@ -780,6 +780,8 @@ PlayerSettings:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
   - {fileID: 11400000, guid: 8383bc818588f794f82d39eafdf30719, type: 2}
   - {fileID: 0}
   - {fileID: -8158722226129811354, guid: 76fd00d40ec5aca4781936bf3d94abd7, type: 2}

--- a/PenguinsCanFly/ProjectSettings/ProjectSettings.asset
+++ b/PenguinsCanFly/ProjectSettings/ProjectSettings.asset
@@ -728,6 +728,8 @@ PlayerSettings:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
   - {fileID: 11400000, guid: 8383bc818588f794f82d39eafdf30719, type: 2}
   - {fileID: 0}
   - {fileID: -8158722226129811354, guid: 76fd00d40ec5aca4781936bf3d94abd7, type: 2}

--- a/PenguinsCanFly/ProjectSettings/ProjectSettings.asset
+++ b/PenguinsCanFly/ProjectSettings/ProjectSettings.asset
@@ -779,6 +779,7 @@ PlayerSettings:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
+  - {fileID: 0}
   - {fileID: 11400000, guid: 8383bc818588f794f82d39eafdf30719, type: 2}
   - {fileID: 0}
   - {fileID: -8158722226129811354, guid: 76fd00d40ec5aca4781936bf3d94abd7, type: 2}

--- a/PenguinsCanFly/ProjectSettings/ProjectSettings.asset
+++ b/PenguinsCanFly/ProjectSettings/ProjectSettings.asset
@@ -737,9 +737,7 @@ PlayerSettings:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
-  - {fileID: 11400000, guid: 8383bc818588f794f82d39eafdf30719, type: 2}
   - {fileID: 0}
-  - {fileID: -8158722226129811354, guid: 76fd00d40ec5aca4781936bf3d94abd7, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
Obstacles
- Minimum spawn height for obstacles
- Hide cosmetic obstacles, was too cluttered
- Make obstacles destroy on collision, despawn when they are too far behind you
- Balloons are statistically less likely than snowflakes
- Haptic buzz when you hit an obstacle

Checkpoints
- Despawn when the user moves past them
- Dynamic checkpoint spawn distance - there's a hacky workaround for now, can probably make it better if we fix the pitch problem (pitching up makes you travel further depending on your speed). Also i don't understand why this equation works bc I think there's supposed to be a square root but somehow it's a decent approximation?
- Changed so hitting checkpoint manipulates transform position instead of adding a force. But this is basically useless for now since there's still the pitch issue, and the value I set it to is way too small.